### PR TITLE
Many bug fixes combined into one PR

### DIFF
--- a/LethalProgression/LP_NetworkManager.cs
+++ b/LethalProgression/LP_NetworkManager.cs
@@ -8,6 +8,9 @@ namespace LethalProgression
     [HarmonyPatch]
     internal class LP_NetworkManager
     {
+        public static LC_XP xpInstance;
+        public static GameObject xpNetworkObject;
+
         [HarmonyPostfix]
         [HarmonyPatch(typeof(GameNetworkManager), "Start")]
         public static void Init()
@@ -20,21 +23,19 @@ namespace LethalProgression
             NetworkManager.Singleton.AddNetworkPrefab(xpNetworkObject);
         }
 
-        public static GameObject xpNetworkObject;
-
         [HarmonyPostfix]
         [HarmonyPatch(typeof(StartOfRound), "Awake")]
         static void SpawnNetworkHandler()
         {
             if (NetworkManager.Singleton.IsHost || NetworkManager.Singleton.IsServer)
             {
-                var networkHandlerHost = Object.Instantiate(xpNetworkObject, Vector3.zero, Quaternion.identity);
+                GameObject networkHandlerHost = Object.Instantiate(xpNetworkObject, Vector3.zero, Quaternion.identity);
+
                 networkHandlerHost.GetComponent<NetworkObject>().Spawn();
                 xpInstance = networkHandlerHost.GetComponent<LC_XP>();
+                
                 LethalPlugin.Log.LogInfo("XPHandler Initialized.");
             }
         }
-
-        public static LC_XP xpInstance;
     }
 }

--- a/LethalProgression/LP_NetworkManager.cs
+++ b/LethalProgression/LP_NetworkManager.cs
@@ -20,6 +20,7 @@ namespace LethalProgression
 
             xpNetworkObject = (GameObject)LethalPlugin.skillBundle.LoadAsset("LP_XPHandler");
             xpNetworkObject.AddComponent<LC_XP>();
+
             NetworkManager.Singleton.AddNetworkPrefab(xpNetworkObject);
         }
 
@@ -32,8 +33,9 @@ namespace LethalProgression
                 GameObject networkHandlerHost = Object.Instantiate(xpNetworkObject, Vector3.zero, Quaternion.identity);
 
                 networkHandlerHost.GetComponent<NetworkObject>().Spawn();
+
                 xpInstance = networkHandlerHost.GetComponent<LC_XP>();
-                
+
                 LethalPlugin.Log.LogInfo("XPHandler Initialized.");
             }
         }

--- a/LethalProgression/LP_NetworkManager.cs
+++ b/LethalProgression/LP_NetworkManager.cs
@@ -1,7 +1,4 @@
 ﻿using HarmonyLib;
-using System;
-using System.Collections.Generic;
-using System.Text;
 using Unity.Netcode;
 using UnityEngine;
 using Object = UnityEngine.Object;

--- a/LethalProgression/LethalProgression.csproj
+++ b/LethalProgression/LethalProgression.csproj
@@ -77,7 +77,6 @@
     <ItemGroup Condition="$(CI) != 'true'">
         <!-- List of game assembly to include as reference -->
         <DllNames Include="Assembly-CSharp" Publicize="true" />
-        <DllNames Include="Unity.Netcode.Runtime" />
         <DllNames Include="ClientNetworkTransform" />
         <DllNames Include="Facepunch.Steamworks.Win64" />
         <DllNames Include="Newtonsoft.Json" />

--- a/LethalProgression/LethalProgression.csproj
+++ b/LethalProgression/LethalProgression.csproj
@@ -62,7 +62,11 @@
         <PackageReference Include="BepInEx.Analyzers" Version="1.*" PrivateAssets="all" />
         <PackageReference Include="BepInEx.Core" Version="5.*" />
         <PackageReference Include="BepInEx.PluginInfoProps" Version="1.*" />
-        <PackageReference Include="UnityEngine.Modules" Version="2022.3.9" IncludeAssets="compile" />
+        <PackageReference Include="Xilophor.LethalNetworkAPI" Version="2.*" PrivateAssets="all"/>
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework.TrimEnd(`0123456789`))' == 'net'">
+        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="all" />
     </ItemGroup>
 
     <!-- Avoid that the game's assemblies are copied to the plugin's target directory -->
@@ -77,7 +81,6 @@
     <ItemGroup Condition="$(CI) != 'true'">
         <!-- List of game assembly to include as reference -->
         <DllNames Include="Assembly-CSharp" Publicize="true" />
-        <DllNames Include="ClientNetworkTransform" />
         <DllNames Include="Facepunch.Steamworks.Win64" />
         <DllNames Include="Newtonsoft.Json" />
         <DllNames Include="Unity.TextMeshPro" />
@@ -129,9 +132,9 @@
     <!-- https://github.com/EvaisaDev/UnityNetcodePatcher#usage-as-a-post-build-event -->
     <!-- Syntax to use the tool installed globally -->
     <!-- Allows to patch elements like networked behaviours, RPCs, etc. -->
-    <Target Name="NetcodePatch" AfterTargets="PostBuildEvent">
+    <!-- <Target Name="NetcodePatch" AfterTargets="PostBuildEvent">
         <Exec Command="netcode-patch &quot;$(TargetPath)&quot; @(ReferencePathWithRefAssemblies->'&quot;%(Identity)&quot;', ' ')"/>
-    </Target>
+    </Target> -->
 
     <!-- On CI build, the assemblies are downloaded from NuGet -->
     <ItemGroup Condition="$(CI) == 'true'">

--- a/LethalProgression/Network/PlayerHandSlotData.cs
+++ b/LethalProgression/Network/PlayerHandSlotData.cs
@@ -1,0 +1,16 @@
+using LethalProgression.Saving;
+
+namespace LethalProgression.Network
+{
+    internal class PlayerHandSlotData
+    {
+        public ulong clientId { get; set; }
+        public int additionalSlots { get; set; }
+
+        public PlayerHandSlotData(ulong clientId, int additionalSlots)
+        {
+            this.clientId = clientId;
+            this.additionalSlots = additionalSlots;
+        }
+    }
+}

--- a/LethalProgression/Network/SaveProfileData.cs
+++ b/LethalProgression/Network/SaveProfileData.cs
@@ -1,0 +1,16 @@
+using LethalProgression.Saving;
+
+namespace LethalProgression.Network
+{
+    internal class SaveProfileData
+    {
+        public ulong steamId { get; set; }
+        public SaveData saveData { get; set; }
+
+        public SaveProfileData(ulong steamId, SaveData saveData)
+        {
+            this.steamId = steamId;
+            this.saveData = saveData;
+        }
+    }
+}

--- a/LethalProgression/Patches/Config.cs
+++ b/LethalProgression/Patches/Config.cs
@@ -12,44 +12,44 @@ namespace LethalProgression.Config
                 "Person Multiplier",
                 35,
                 "How much does XP cost to level up go up per person?"
-                );
+            );
 
             LethalPlugin.Instance.BindConfig<int>(
                 "General",
                 "Quota Multiplier",
                 30,
                 "How much more XP does it cost to level up go up per quota? (Percent)"
-                );
+            );
             LethalPlugin.Instance.BindConfig<int>(
                 "General",
                 "XP Minimum",
                 40,
                 "Minimum XP to level up."
-                );
+            );
             LethalPlugin.Instance.BindConfig<int>(
                 "General",
                 "XP Maximum",
                 750,
                 "Maximum XP to level up."
-                );
+            );
             LethalPlugin.Instance.BindConfig<bool>(
                 "General",
                 "Unspec in Ship Only",
                 false,
                 "Disallows unspecing stats if you're not currently on the ship."
-                );
+            );
             LethalPlugin.Instance.BindConfig<bool>(
                 "General",
                 "Unspec in Orbit Only",
                 true,
                 "Disallows unspecing stats if you're not currently in orbit."
-                );
+            );
             LethalPlugin.Instance.BindConfig<bool>(
                 "General",
                 "Disable Unspec",
                 false,
                 "Disallows unspecing altogether."
-                );
+            );
 
             // Skill Configs
             LethalPlugin.Instance.BindConfig<bool>(
@@ -57,21 +57,21 @@ namespace LethalProgression.Config
                 "Health Regen Enabled",
                 true,
                 "Enable the Health Regen skill?"
-                );
+            );
 
             LethalPlugin.Instance.BindConfig<int>(
                 "Skills",
                 "Health Regen Max Level",
                 20,
                 "Maximum level for the health regen."
-                );
+            );
 
             LethalPlugin.Instance.BindConfig<float>(
                 "Skills",
                 "Health Regen Multiplier",
                 0.05f,
                 "How much does the health regen skill increase per level?"
-                );
+            );
 
             //
             LethalPlugin.Instance.BindConfig<bool>(
@@ -79,21 +79,21 @@ namespace LethalProgression.Config
                 "Stamina Enabled",
                 true,
                 "Enable the Stamina skill?"
-                );
+            );
 
             LethalPlugin.Instance.BindConfig<int>(
                 "Skills",
                 "Stamina Max Level",
                 99999,
                 "Maximum level for the stamina."
-                );
+            );
 
             LethalPlugin.Instance.BindConfig<float>(
                 "Skills",
                 "Stamina Multiplier",
                 2,
                 "How much does the stamina skill increase per level?"
-                );
+            );
 
             //
             LethalPlugin.Instance.BindConfig<bool>(
@@ -101,21 +101,21 @@ namespace LethalProgression.Config
                 "Battery Life Enabled",
                 true,
                 "Enable the Battery Life skill?"
-                );
+            );
 
             LethalPlugin.Instance.BindConfig<int>(
                 "Skills",
                 "Battery Life Max Level",
                 99999,
                 "Maximum level for the battery life."
-                );
+            );
 
             LethalPlugin.Instance.BindConfig<float>(
                 "Skills",
                 "Battery Life Multiplier",
                 5,
                 "How much does the battery life skill increase per level?"
-                );
+            );
 
             //
             LethalPlugin.Instance.BindConfig<bool>(
@@ -123,21 +123,21 @@ namespace LethalProgression.Config
                 "Hand Slots Enabled",
                 true,
                 "Enable the Hand Slots skill?"
-                );
+            );
 
             LethalPlugin.Instance.BindConfig<int>(
                 "Skills",
                 "Hand Slots Max Level",
                 30,
                 "Maximum level for the hand slots."
-                );
+            );
 
             LethalPlugin.Instance.BindConfig<float>(
                 "Skills",
                 "Hand Slots Multiplier",
                 10,
                 "How much does the hand slots skill increase per level?"
-                );
+            );
 
             //
             LethalPlugin.Instance.BindConfig<bool>(
@@ -145,21 +145,21 @@ namespace LethalProgression.Config
                 "Loot Value Enabled",
                 true,
                 "Enable the Loot Value skill?"
-                );
+            );
 
             LethalPlugin.Instance.BindConfig<int>(
                 "Skills",
                 "Loot Value Max Level",
                 250,
                 "Maximum level for the loot value."
-                );
+            );
 
             LethalPlugin.Instance.BindConfig<float>(
                 "Skills",
                 "Loot Value Multiplier",
                 0.1f,
                 "How much does the loot value skill increase per level?"
-                );
+            );
 
             //
             LethalPlugin.Instance.BindConfig<bool>(
@@ -167,84 +167,84 @@ namespace LethalProgression.Config
                 "Oxygen Enabled",
                 true,
                 "Enable the Oxygen skill?"
-                );
+            );
 
             LethalPlugin.Instance.BindConfig<int>(
                 "Skills",
                 "Oxygen Max Level",
                 99999,
                 "Maximum level for Oxygen."
-                );
+            );
 
             LethalPlugin.Instance.BindConfig<float>(
                 "Skills",
                 "Oxygen Multiplier",
                 1f,
                 "How much does the Oxygen skill increase per level?"
-                );
+            );
             //
             LethalPlugin.Instance.BindConfig<bool>(
                 "Skills",
                 "Jump Height Enabled",
                 true,
                 "Enable the Jump Height skill?"
-                );
+            );
 
             LethalPlugin.Instance.BindConfig<int>(
                 "Skills",
                 "Jump Height Max Level",
                 99999,
                 "Maximum level for Jump Height."
-                );
+            );
 
             LethalPlugin.Instance.BindConfig<float>(
                 "Skills",
                 "Jump Height Multiplier",
                 3f,
                 "How much does the Jump Height skill increase per level?"
-                );
+            );
             //
             LethalPlugin.Instance.BindConfig<bool>(
                 "Skills",
                 "Sprint Speed Enabled",
                 true,
                 "Enable the Sprint Speed skill?"
-                );
+            );
 
             LethalPlugin.Instance.BindConfig<int>(
                 "Skills",
                 "Sprint Speed Max Level",
                 99999,
                 "Maximum level for Sprint Speed."
-                );
+            );
 
             LethalPlugin.Instance.BindConfig<float>(
                 "Skills",
                 "Sprint Speed Multiplier",
                 0.25f,
                 "How much does the Sprint Speed skill increase per level?"
-                );
+            );
             //
             LethalPlugin.Instance.BindConfig<bool>(
                 "Skills",
                 "Strength Enabled",
                 true,
                 "Enable the strength skill?"
-                );
+            );
 
             LethalPlugin.Instance.BindConfig<int>(
                 "Skills",
                 "Strength Max Level",
                 75,
                 "Maximum level for Strength."
-                );
+            );
 
             LethalPlugin.Instance.BindConfig<float>(
                 "Skills",
                 "Strength Multiplier",
                 1f,
                 "How much does the Strength skill increase per level?"
-                );
+            );
         }
     }
 }

--- a/LethalProgression/Patches/Config.cs
+++ b/LethalProgression/Patches/Config.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using HarmonyLib;
-using BepInEx.Configuration;
+﻿using System.Collections.Generic;
 
 namespace LethalProgression.Config
 {

--- a/LethalProgression/Patches/HudManagerPatch.cs
+++ b/LethalProgression/Patches/HudManagerPatch.cs
@@ -1,10 +1,6 @@
 ﻿using HarmonyLib;
-using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;

--- a/LethalProgression/Patches/HudManagerPatch.cs
+++ b/LethalProgression/Patches/HudManagerPatch.cs
@@ -29,12 +29,12 @@ namespace LethalProgression.Patches
             { "Puffer (EnemyType)", 15 },
         };
 
-        //[HarmonyPostfix]
-        //[HarmonyPatch(typeof(HUDManager), "PingScan_performed")]
-        //private static void DebugScan()
-        //{
-        //    LethalProgression.XPHandler.xpInstance.AddXPServerRPC(10);
-        //}
+        // [HarmonyPostfix]
+        // [HarmonyPatch(typeof(HUDManager), "PingScan_performed")]
+        // private static void DebugScan()
+        // {
+        //    LP_NetworkManager.xpInstance.updateTeamXPClientMessage.SendServer(10);
+        // }
 
         [HarmonyPrefix]
         [HarmonyPatch(typeof(HUDManager), "AddNewScrapFoundToDisplay")]
@@ -47,32 +47,38 @@ namespace LethalProgression.Patches
             int scrapCost = GObject.scrapValue;
 
             // Give XP for the amount of money this scrap costs.
-            LP_NetworkManager.xpInstance.AddXPServerRPC(scrapCost);
+            LP_NetworkManager.xpInstance.updateTeamXPClientMessage.SendServer(scrapCost);
         }
+        
         [HarmonyPostfix]
         [HarmonyPatch(typeof(EnemyAI), "KillEnemy")]
         private static void GiveXPForKill(EnemyAI __instance)
         {
             string enemyType = __instance.enemyType.ToString();
             LethalPlugin.Log.LogInfo("Enemy type: " + enemyType);
+            
             // Give XP for the amount of money this scrap costs.
             int enemyReward = 30;
             if (_enemyReward.ContainsKey(enemyType))
             {
                 enemyReward = _enemyReward[enemyType];
             }
-            LP_NetworkManager.xpInstance.AddXPServerRPC(enemyReward);
+
+            LP_NetworkManager.xpInstance.updateTeamXPClientMessage.SendServer(enemyReward);
         }
-        public static void ShowXPUpdate(int oldXP, int newXP, int xp)
+
+        public static void ShowXPUpdate()
         {
             // Makes one if it doesn't exist on screen yet.
             if (!_tempBar)
                 MakeBar();
+            
+            LC_XP xpInstance = LP_NetworkManager.xpInstance;
 
             GameObject _tempprogress = GameObject.Find("/Systems/UI/Canvas/IngamePlayerHUD/BottomMiddle/XPUpdate/XPBarProgress");
 
-            _tempprogress.GetComponent<Image>().fillAmount = newXP / (float)LP_NetworkManager.xpInstance.GetXPRequirement();
-            _tempText.text = newXP + " / " + (float)LP_NetworkManager.xpInstance.GetXPRequirement();
+            _tempprogress.GetComponent<Image>().fillAmount = xpInstance.teamXP.Value / (float)xpInstance.CalculateXPRequirement();
+            _tempText.text = xpInstance.teamXP.Value + " / " + (float)xpInstance.CalculateXPRequirement();
 
             _tempBarTime = 2f;
 

--- a/LethalProgression/Patches/QuickMenuManagerPatch.cs
+++ b/LethalProgression/Patches/QuickMenuManagerPatch.cs
@@ -1,16 +1,7 @@
 ﻿using HarmonyLib;
-using BepInEx.Configuration;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.IO;
-using System.Xml.Linq;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
-using Object = UnityEngine.Object;
 
 namespace LethalProgression.Patches
 {

--- a/LethalProgression/Patches/QuickMenuManagerPatch.cs
+++ b/LethalProgression/Patches/QuickMenuManagerPatch.cs
@@ -47,11 +47,11 @@ namespace LethalProgression.Patches
             // XP Text. Values of how much XP you need to level up.
             // XP Level, which is just the level you're on.
             // Profit, which is how much money you've made.
-            _xpText.text = xpInstance.GetXP().ToString() + " / " + xpInstance.xpReq.Value.ToString();
+            _xpText.text = xpInstance.GetXP().ToString() + " / " + xpInstance.teamXPRequired.Value.ToString();
             _xpLevel.text = "Level: " + xpInstance.GetLevel().ToString();
             _profit.text = "You've made.. " + xpInstance.GetProfit().ToString() + "$";
             // Set the bar fill
-            _xpBarProgress.GetComponent<Image>().fillAmount = xpInstance.GetXP() / (float)xpInstance.xpReq.Value;
+            _xpBarProgress.GetComponent<Image>().fillAmount = xpInstance.GetXP() / (float)xpInstance.teamXPRequired.Value;
         }
 
         public static void MakeNewXPBar()

--- a/LethalProgression/Patches/QuickMenuManagerPatch.cs
+++ b/LethalProgression/Patches/QuickMenuManagerPatch.cs
@@ -14,6 +14,7 @@ namespace LethalProgression.Patches
         private static TextMeshProUGUI _xpText;
         private static TextMeshProUGUI _xpLevel;
         private static TextMeshProUGUI _profit;
+
         [HarmonyPostfix]
         [HarmonyPatch(typeof(QuickMenuManager), "OpenQuickMenu")]
         private static void QuickMenuXPBar(QuickMenuManager __instance)
@@ -36,6 +37,8 @@ namespace LethalProgression.Patches
             if (!_xpInfoContainer || !_xpBar || !_xpBarProgress)
                 return;
 
+            LC_XP xpInstance = LP_NetworkManager.xpInstance;
+
             // If the settings menu or exit game menu is open, we don't want to show the XP bar.
             bool activeState = __instance.mainButtonsPanel.activeSelf;
             _xpInfoContainer.SetActive(activeState);
@@ -44,11 +47,11 @@ namespace LethalProgression.Patches
             // XP Text. Values of how much XP you need to level up.
             // XP Level, which is just the level you're on.
             // Profit, which is how much money you've made.
-            _xpText.text = LP_NetworkManager.xpInstance.GetXP().ToString() + " / " + LP_NetworkManager.xpInstance.xpReq.Value.ToString();
-            _xpLevel.text = "Level: " + LP_NetworkManager.xpInstance.GetLevel().ToString();
-            _profit.text = "You've made.. " + LP_NetworkManager.xpInstance.GetProfit().ToString() + "$";
+            _xpText.text = xpInstance.GetXP().ToString() + " / " + xpInstance.xpReq.Value.ToString();
+            _xpLevel.text = "Level: " + xpInstance.GetLevel().ToString();
+            _profit.text = "You've made.. " + xpInstance.GetProfit().ToString() + "$";
             // Set the bar fill
-            _xpBarProgress.GetComponent<Image>().fillAmount = LP_NetworkManager.xpInstance.GetXP() / (float)LP_NetworkManager.xpInstance.xpReq.Value;
+            _xpBarProgress.GetComponent<Image>().fillAmount = xpInstance.GetXP() / (float)xpInstance.xpReq.Value;
         }
 
         public static void MakeNewXPBar()

--- a/LethalProgression/Patches/XPPatches.cs
+++ b/LethalProgression/Patches/XPPatches.cs
@@ -1,4 +1,4 @@
-﻿using HarmonyLib;
+using HarmonyLib;
 using LethalProgression.Skills;
 using LethalProgression.GUI;
 using Steamworks;
@@ -39,7 +39,7 @@ namespace LethalProgression.Patches
             {
                 int localLootLevel = LP_NetworkManager.xpInstance.skillList.skills[UpgradeType.Value].GetLevel();
 
-                LP_NetworkManager.xpInstance.TeamLootValueUpdate(-localLootLevel);
+                LP_NetworkManager.xpInstance.TeamLootLevelUpdate(-localLootLevel);
             }
 
             SprintSpeed.sprintSpeed = 2.25f;
@@ -67,6 +67,7 @@ namespace LethalProgression.Patches
             {
                 return;
             }
+
             LP_NetworkManager.xpInstance.xpReq.Value = LP_NetworkManager.xpInstance.GetXPRequirement();
         }
     }

--- a/LethalProgression/Patches/XPPatches.cs
+++ b/LethalProgression/Patches/XPPatches.cs
@@ -1,10 +1,5 @@
-﻿using HarmonyLib;
+using HarmonyLib;
 using LethalProgression.Skills;
-using System;
-using System.Collections.Generic;
-using System.Text;
-using UnityEngine;
-using Unity.Netcode;
 using LethalProgression.GUI;
 using Steamworks;
 using GameNetcodeStuff;

--- a/LethalProgression/Patches/XPPatches.cs
+++ b/LethalProgression/Patches/XPPatches.cs
@@ -1,4 +1,4 @@
-using HarmonyLib;
+﻿using HarmonyLib;
 using LethalProgression.Skills;
 using LethalProgression.GUI;
 using Steamworks;
@@ -28,7 +28,7 @@ namespace LethalProgression.Patches
             xpInstance.xpLevel.Value = 0;
             xpInstance.xpPoints.Value = 0;
             xpInstance.profit.Value = 0;
-            xpInstance.teamLootValue.Value = 0;
+            xpInstance.teamLootLevel.Value = 0;
         }
 
         [HarmonyPostfix]
@@ -37,7 +37,9 @@ namespace LethalProgression.Patches
         {
             if (LP_NetworkManager.xpInstance.skillList.GetSkill(UpgradeType.Value).GetLevel() != 0)
             {
-                LP_NetworkManager.xpInstance.TeamLootValueUpdate(0);
+                int localLootLevel = LP_NetworkManager.xpInstance.skillList.skills[UpgradeType.Value].GetLevel();
+
+                LP_NetworkManager.xpInstance.TeamLootValueUpdate(-localLootLevel);
             }
 
             SprintSpeed.sprintSpeed = 2.25f;

--- a/LethalProgression/Plugin.cs
+++ b/LethalProgression/Plugin.cs
@@ -11,12 +11,12 @@ using LethalProgression.Config;
 namespace LethalProgression
 {
     [BepInDependency("LethalNetworkAPI")]
-    [BepInPlugin("Stoneman.LethalProgression", "Lethal Progression", "1.6.0")]
+    [BepInPlugin("Stoneman.LethalProgression", "Lethal Progression", "1.7.0")]
     internal class LethalPlugin : BaseUnityPlugin
     {
         private const string modGUID = "Stoneman.LethalProgression";
         private const string modName = "Lethal Progression";
-        private const string modVersion = "1.6.0";
+        private const string modVersion = "1.7.0";
         private const string modAuthor = "Stoneman";
         public static AssetBundle skillBundle;
 

--- a/LethalProgression/Plugin.cs
+++ b/LethalProgression/Plugin.cs
@@ -2,22 +2,12 @@
 using UnityEngine;
 using HarmonyLib;
 using BepInEx.Configuration;
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using BepInEx.Logging;
 using System.Reflection;
-using System.IO;
-using UnityEngine.SceneManagement;
 using BepInEx.Bootstrap;
-using LethalProgression.GUI;
-using LethalProgression.Skills;
-using LethalProgression.Patches;
 using LethalProgression.Config;
-using Unity.Netcode;
-using UnityEngine;
 
 namespace LethalProgression
 {

--- a/LethalProgression/Plugin.cs
+++ b/LethalProgression/Plugin.cs
@@ -5,12 +5,12 @@ using BepInEx.Configuration;
 using System.Collections.Generic;
 using System.Linq;
 using BepInEx.Logging;
-using System.Reflection;
 using BepInEx.Bootstrap;
 using LethalProgression.Config;
 
 namespace LethalProgression
 {
+    [BepInDependency("LethalNetworkAPI")]
     [BepInPlugin("Stoneman.LethalProgression", "Lethal Progression", "1.6.0")]
     internal class LethalPlugin : BaseUnityPlugin
     {
@@ -30,9 +30,9 @@ namespace LethalProgression
             Instance = this;
 
             var harmony = new Harmony(modGUID);
-            harmony.PatchAll(Assembly.GetExecutingAssembly());
+            harmony.PatchAll();
 
-            skillBundle = AssetBundle.LoadFromMemory(LethalProgression.Properties.Resources.skillmenu);
+            skillBundle = AssetBundle.LoadFromMemory(Properties.Resources.skillmenu);
 
             Log = Logger;
 
@@ -61,21 +61,6 @@ namespace LethalProgression
                                 ReservedSlots = true;
                             }
                         }
-                    }
-                }
-            }
-
-            // Network patcher!
-            var types = Assembly.GetExecutingAssembly().GetTypes();
-            foreach (var type in types)
-            {
-                var methods = type.GetMethods(BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static);
-                foreach (var method in methods)
-                {
-                    var attributes = method.GetCustomAttributes(typeof(RuntimeInitializeOnLoadMethodAttribute), false);
-                    if (attributes.Length > 0)
-                    {
-                        method.Invoke(null, null);
                     }
                 }
             }

--- a/LethalProgression/Saving/SaveData.cs
+++ b/LethalProgression/Saving/SaveData.cs
@@ -1,8 +1,5 @@
 ﻿using LethalProgression.Skills;
-using Steamworks;
-using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace LethalProgression.Saving
 {

--- a/LethalProgression/Saving/SaveManager.cs
+++ b/LethalProgression/Saving/SaveManager.cs
@@ -1,8 +1,6 @@
-﻿using System.Collections.Generic;
-using UnityEngine;
+﻿using UnityEngine;
 using Newtonsoft.Json;
 using System.IO;
-using Steamworks;
 
 namespace LethalProgression.Saving
 {

--- a/LethalProgression/Saving/SaveManager.cs
+++ b/LethalProgression/Saving/SaveManager.cs
@@ -11,7 +11,7 @@ namespace LethalProgression.Saving
         {
             saveFileSlot = GameNetworkManager.Instance.saveFileNum;
 
-            LethalPlugin.Log.LogInfo("Saving to slot " + saveFileSlot + 1);
+            LethalPlugin.Log.LogInfo($"Saving to slot {saveFileSlot + 1} in {GetSavePath()}");
 
             // If file doesn't exist, create it
             if (!Directory.Exists(GetSavePath()))

--- a/LethalProgression/Saving/SaveManager.cs
+++ b/LethalProgression/Saving/SaveManager.cs
@@ -52,21 +52,24 @@ namespace LethalProgression.Saving
             return Application.persistentDataPath + "/lethalprogression/save" + (saveFileSlot + 1) + "/";
         }
 
-        public static string Load(ulong steamId)
+        public static string LoadPlayerFile(ulong steamId)
         {
             saveFileSlot = GameNetworkManager.Instance.saveFileNum;
 
             if (!File.Exists(GetSavePath() + steamId + ".json"))
             {
+                LethalPlugin.Log.LogInfo($"Player file for {steamId} doesn't exist");
                 return null;
             }
+
+            LethalPlugin.Log.LogInfo($"Player file for {steamId} found");
 
             string json = File.ReadAllText(GetSavePath() + steamId + ".json");
 
             return json;
         }
 
-        public static SaveSharedData LoadShared()
+        public static SaveSharedData LoadSharedFile()
         {
             saveFileSlot = GameNetworkManager.Instance.saveFileNum;
 
@@ -76,8 +79,10 @@ namespace LethalProgression.Saving
                 return null;
             }
 
-            string json = File.ReadAllText(GetSavePath() + "shared.json");
             LethalPlugin.Log.LogInfo("Shared file exists");
+
+            string json = File.ReadAllText(GetSavePath() + "shared.json");
+
             return JsonConvert.DeserializeObject<SaveSharedData>(json);
         }
     }

--- a/LethalProgression/Saving/SavePatches.cs
+++ b/LethalProgression/Saving/SavePatches.cs
@@ -1,6 +1,4 @@
-﻿using System;
 using System.Collections.Generic;
-using System.Text;
 using HarmonyLib;
 using LethalProgression.Skills;
 using Newtonsoft.Json;

--- a/LethalProgression/Saving/SavePatches.cs
+++ b/LethalProgression/Saving/SavePatches.cs
@@ -1,51 +1,20 @@
-﻿using System.Collections.Generic;
-using HarmonyLib;
-using LethalProgression.Skills;
-using Newtonsoft.Json;
+﻿using HarmonyLib;
+using Unity.Netcode;
+using Steamworks;
 
 namespace LethalProgression.Saving
 {
     [HarmonyPatch]
-    internal class SavePatches
+    internal class SavePatches : NetworkBehaviour
     {
         // Whenever game saves, do save!
         [HarmonyPrefix]
         [HarmonyPatch(typeof(GameNetworkManager), "SaveGame")]
-        private static void SaveGame(GameNetworkManager __instance)
+        [HarmonyPriority(Priority.First)]
+        private static void SaveGamePrefix()
         {
             LethalPlugin.Log.LogDebug("Invoked DoSave via SaveGame");
-            DoSave(__instance);
-        }
-
-        // Whenever disconnect
-        [HarmonyPrefix]
-        [HarmonyPatch(typeof(GameNetworkManager), "Disconnect")]
-        private static void Disconnect(GameNetworkManager __instance)
-        {
-            if (__instance.currentLobby == null)
-                return;
-
-            LethalPlugin.Log.LogDebug("Invoked DoSave via Disconnect");
-
-            DoSave(__instance);
-        }
-
-        public static void DoSave(GameNetworkManager __instance)
-        {
-            SaveData saveData = new SaveData
-            {
-                steamId = __instance.localPlayerController.playerSteamId,
-                skillPoints = LP_NetworkManager.xpInstance.skillPoints
-            };
-
-            foreach (KeyValuePair<UpgradeType, Skill> skill in LP_NetworkManager.xpInstance.skillList.skills)
-            {
-                LethalPlugin.Log.LogInfo($"Skill is {skill.Key} and value is {skill.Value.GetLevel()}");
-                saveData.skillAllocation.Add(skill.Key, skill.Value.GetLevel());
-            }
-
-            string data = JsonConvert.SerializeObject(saveData);
-            LP_NetworkManager.xpInstance.SaveData_ServerRpc(__instance.localPlayerController.playerSteamId, data);
+            SaveManager.TriggerHostProfileSave();
         }
 
         [HarmonyPostfix]

--- a/LethalProgression/SkillBase.cs
+++ b/LethalProgression/SkillBase.cs
@@ -68,7 +68,6 @@ namespace LethalProgression.Skills
         {
             if (bool.Parse(SkillConfig.hostConfig["Health Regen Enabled"]))
             {
-                LethalPlugin.Log.LogInfo("HP Regen check 1");
                 CreateSkill(UpgradeType.HPRegen,
                     "Health Regen",
                     "The company installs a basic healer into your suit, letting you regenerate health slowly. Only regenerate up to 100 HP.",
@@ -76,7 +75,8 @@ namespace LethalProgression.Skills
                     "Health Regeneration",
                     1,
                     int.Parse(SkillConfig.hostConfig["Health Regen Max Level"]),
-                    float.Parse(SkillConfig.hostConfig["Health Regen Multiplier"], CultureInfo.InvariantCulture));
+                    float.Parse(SkillConfig.hostConfig["Health Regen Multiplier"], CultureInfo.InvariantCulture)
+                );
             }
 
             if (bool.Parse(SkillConfig.hostConfig["Stamina Enabled"]))
@@ -89,7 +89,8 @@ namespace LethalProgression.Skills
                     1,
                     int.Parse(SkillConfig.hostConfig["Stamina Max Level"]),
                     float.Parse(SkillConfig.hostConfig["Stamina Multiplier"], CultureInfo.InvariantCulture),
-                    Stamina.StaminaUpdate);
+                    Stamina.StaminaUpdate
+                );
             }
 
             if (bool.Parse(SkillConfig.hostConfig["Battery Life Enabled"]))
@@ -101,20 +102,22 @@ namespace LethalProgression.Skills
                     "Battery Life",
                     1,
                     int.Parse(SkillConfig.hostConfig["Battery Life Max Level"]),
-                    float.Parse(SkillConfig.hostConfig["Battery Life Multiplier"], CultureInfo.InvariantCulture));
+                    float.Parse(SkillConfig.hostConfig["Battery Life Multiplier"], CultureInfo.InvariantCulture)
+                );
             }
 
             if (bool.Parse(SkillConfig.hostConfig["Hand Slots Enabled"]) && !LethalPlugin.ReservedSlots)
             {
                  CreateSkill(UpgradeType.HandSlot,
-                     "Hand Slot",
-                     "The company finally gives you a better belt! Fit more stuff! (One slot every 100%.)",
-                     "HND",
-                     "Hand Slots",
-                     1,
-                     int.Parse(SkillConfig.hostConfig["Hand Slots Max Level"]),
-                     float.Parse(SkillConfig.hostConfig["Hand Slots Multiplier"], CultureInfo.InvariantCulture),
-                     HandSlots.HandSlotsUpdate);
+                    "Hand Slot",
+                    "The company finally gives you a better belt! Fit more stuff! (One slot every 100%.)",
+                    "HND",
+                    "Hand Slots",
+                    1,
+                    int.Parse(SkillConfig.hostConfig["Hand Slots Max Level"]),
+                    float.Parse(SkillConfig.hostConfig["Hand Slots Multiplier"], CultureInfo.InvariantCulture),
+                    HandSlots.HandSlotsUpdate
+                );
             }
 
             if (bool.Parse(SkillConfig.hostConfig["Loot Value Enabled"]))
@@ -127,7 +130,8 @@ namespace LethalProgression.Skills
                     1,
                     int.Parse(SkillConfig.hostConfig["Loot Value Max Level"]),
                     float.Parse(SkillConfig.hostConfig["Loot Value Multiplier"], CultureInfo.InvariantCulture),
-                    LootValue.LootValueUpdate);
+                    LootValue.LootValueUpdate
+                );
             }
 
             if (bool.Parse(SkillConfig.hostConfig["Oxygen Enabled"]))
@@ -139,7 +143,8 @@ namespace LethalProgression.Skills
                     "Extra Oxygen",
                     1,
                     int.Parse(SkillConfig.hostConfig["Oxygen Max Level"]),
-                    float.Parse(SkillConfig.hostConfig["Oxygen Multiplier"], CultureInfo.InvariantCulture));
+                    float.Parse(SkillConfig.hostConfig["Oxygen Multiplier"], CultureInfo.InvariantCulture)
+                );
             }
 
             if (bool.Parse(SkillConfig.hostConfig["Strength Enabled"]))
@@ -152,7 +157,8 @@ namespace LethalProgression.Skills
                     1,
                     int.Parse(SkillConfig.hostConfig["Strength Max Level"]),
                     float.Parse(SkillConfig.hostConfig["Strength Multiplier"], CultureInfo.InvariantCulture),
-                    Strength.StrengthUpdate);
+                    Strength.StrengthUpdate
+                );
             }
 
             if (bool.Parse(SkillConfig.hostConfig["Jump Height Enabled"]))
@@ -165,7 +171,8 @@ namespace LethalProgression.Skills
                     1,
                     int.Parse(SkillConfig.hostConfig["Jump Height Max Level"]),
                     float.Parse(SkillConfig.hostConfig["Jump Height Multiplier"], CultureInfo.InvariantCulture),
-                    JumpHeight.JumpHeightUpdate);
+                    JumpHeight.JumpHeightUpdate
+                );
             }
 
             if (!LethalPlugin.MikesTweaks && bool.Parse(SkillConfig.hostConfig["Sprint Speed Enabled"]))
@@ -178,7 +185,8 @@ namespace LethalProgression.Skills
                     1,
                     int.Parse(SkillConfig.hostConfig["Sprint Speed Max Level"]),
                     float.Parse(SkillConfig.hostConfig["Sprint Speed Multiplier"], CultureInfo.InvariantCulture),
-                    SprintSpeed.SprintSpeedUpdate);
+                    SprintSpeed.SprintSpeedUpdate
+                );
             }
         }
     }

--- a/LethalProgression/SkillBase.cs
+++ b/LethalProgression/SkillBase.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using LethalProgression.Config;
 using System.Globalization;
+using LethalProgression.Saving;
 
 namespace LethalProgression.Skills
 {
@@ -130,7 +131,8 @@ namespace LethalProgression.Skills
                     1,
                     int.Parse(SkillConfig.hostConfig["Loot Value Max Level"]),
                     float.Parse(SkillConfig.hostConfig["Loot Value Multiplier"], CultureInfo.InvariantCulture),
-                    LootValue.LootValueUpdate
+                    LootValue.LootValueUpdate,
+                    true
                 );
             }
 
@@ -271,11 +273,16 @@ namespace LethalProgression.Skills
             return _multiplier * _level;
         }
 
-        public void SetLevel(int newLevel)
+        public void SetLevel(int newLevel, bool triggerHostProfileSave = true)
         {
+            int oldLevel = _level;
+
             _level = newLevel;
             // level is number of changes
-            _callback?.Invoke(newLevel - _level);
+            _callback?.Invoke(newLevel - oldLevel);
+
+            if (triggerHostProfileSave)
+                SaveManager.TriggerHostProfileSave();
         }
 
         public void AddLevel(int change)
@@ -283,6 +290,8 @@ namespace LethalProgression.Skills
             _level += change;
 
             _callback?.Invoke(change);
+
+            SaveManager.TriggerHostProfileSave();
         }
     }
 }

--- a/LethalProgression/SkillBase.cs
+++ b/LethalProgression/SkillBase.cs
@@ -15,7 +15,7 @@ namespace LethalProgression.Skills
         Oxygen,
         JumpHeight,
         SprintSpeed,
-        Strength
+        Strength,
     }
 
     internal class SkillList
@@ -267,14 +267,12 @@ namespace LethalProgression.Skills
         {
             _level = newLevel;
             // level is number of changes
-            int changes = newLevel - _level;
-            _callback?.Invoke(changes);
+            _callback?.Invoke(newLevel - _level);
         }
 
         public void AddLevel(int change)
         {
             _level += change;
-            int newLevel = _level;
 
             _callback?.Invoke(change);
         }

--- a/LethalProgression/SkillGUI.cs
+++ b/LethalProgression/SkillGUI.cs
@@ -332,16 +332,15 @@ namespace LethalProgression.GUI
                 amt = allocatedPoints;
             }
 
-            skill.AddLevel(-amt);
-            
+            // Add skill points first to stop desync
             LP_NetworkManager.xpInstance.SetSkillPoints(LP_NetworkManager.xpInstance.GetSkillPoints() + amt);
+
+            skill.AddLevel(-amt);
             UpdateStatInfo(skill);
 
             foreach (var button in skillButtonsList)
-            {
                 if (button.name == skill.GetShortName())
                     LoadSkillData(skill, button);
-            }
         }
 
         // START SPECIAL BOYS:

--- a/LethalProgression/SkillGUI.cs
+++ b/LethalProgression/SkillGUI.cs
@@ -228,6 +228,7 @@ namespace LethalProgression.GUI
         {
             if (skill._teamShared)
                 return;
+            
             GameObject bonusLabel = skillButton.transform.GetChild(1).gameObject;
             bonusLabel.GetComponent<TextMeshProUGUI>().SetText(skill.GetLevel().ToString());
             GameObject attributeLabel = skillButton.transform.GetChild(2).gameObject;
@@ -242,6 +243,7 @@ namespace LethalProgression.GUI
             {
                 if (skill.Value._teamShared)
                     continue;
+
                 GameObject skillButton = skillButtonsList.Find(x => x.name == skill.Value.GetShortName());
                 LoadSkillData(skill.Value, skillButton);
             }
@@ -258,6 +260,7 @@ namespace LethalProgression.GUI
 
             activeSkill = skill;
             upgradeName.SetText(skill.GetName());
+
             if (skill.GetMaxLevel() == 99999)
             {
                 upgradeAmt.SetText($"{skill.GetLevel()}");
@@ -266,6 +269,7 @@ namespace LethalProgression.GUI
             {
                 upgradeAmt.SetText($"{skill.GetLevel()} / {skill.GetMaxLevel()}");
             }
+
             //upgradeAmt.SetText(skill.GetLevel().ToString());
             upgradeDesc.SetText(skill.GetDescription());
 

--- a/LethalProgression/SkillGUI.cs
+++ b/LethalProgression/SkillGUI.cs
@@ -1,15 +1,9 @@
 ﻿using HarmonyLib;
 using LethalProgression.Skills;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using TMPro;
 using UnityEngine;
-using UnityEngine.InputSystem;
 using UnityEngine.UI;
-using LethalProgression.Patches;
 using LethalProgression.Config;
 
 namespace LethalProgression.GUI
@@ -81,6 +75,7 @@ namespace LethalProgression.GUI
 
             RealTimeUpdateInfo();
         }
+
         [HarmonyPostfix]
         [HarmonyPatch(typeof(QuickMenuManager), "CloseQuickMenu")]
         private static void SkillMenuClose(QuickMenuManager __instance)
@@ -97,6 +92,7 @@ namespace LethalProgression.GUI
             points.text = LP_NetworkManager.xpInstance.GetSkillPoints().ToString();
         }
     }
+
     internal class SkillsGUI
     {
         public GameObject mainPanel;
@@ -104,17 +100,21 @@ namespace LethalProgression.GUI
         public Skill activeSkill;
         public GameObject templateSlot;
         public List<GameObject> skillButtonsList = new List<GameObject>();
+
+        public int shownSkills = 0;
+
         public SkillsGUI()
         {
             CreateSkillMenu();
             GUIUpdate.guiInstance = this;
         }
+
         public void OpenSkillMenu()
         {
             GUIUpdate.isMenuOpen = true;
             mainPanel.SetActive(true);
         }
-        public int shownSkills = 0;
+
         public void CreateSkillMenu()
         {
             mainPanel = GameObject.Instantiate(LethalPlugin.skillBundle.LoadAsset<GameObject>("SkillMenu"));
@@ -350,7 +350,7 @@ namespace LethalProgression.GUI
         }
 
         // START SPECIAL BOYS:
-        public void TeamLootHudUpdate(float oldValue, float newValue)
+        public void TeamLootHudUpdate(int oldValue, int newValue)
         {
             foreach (var button in skillButtonsList)
             {
@@ -366,9 +366,12 @@ namespace LethalProgression.GUI
                     bonusLabel.GetComponent<TextMeshProUGUI>().SetText($"{skill.GetLevel()}");
                     button.GetComponentInChildren<TextMeshProUGUI>().SetText($"{skill.GetShortName()}:");
 
+                    float mult = LP_NetworkManager.xpInstance.skillList.skills[UpgradeType.Value].GetMultiplier();
+                    float value = LP_NetworkManager.xpInstance.teamLootLevel.Value * mult;
+
                     GameObject attributeLabel = button.transform.GetChild(2).gameObject;
-                    attributeLabel.GetComponent<TextMeshProUGUI>().SetText($"(+{LP_NetworkManager.xpInstance.teamLootValue.Value}% {skill.GetAttribute()})");
-                    LethalPlugin.Log.LogInfo($"Setting team value hud to {LP_NetworkManager.xpInstance.teamLootValue.Value}");
+                    attributeLabel.GetComponent<TextMeshProUGUI>().SetText($"(+{value}% {skill.GetAttribute()})");
+                    LethalPlugin.Log.LogInfo($"Setting team value hud to {value}");
                 }
             }
         }

--- a/LethalProgression/Skills/BatteryLife.cs
+++ b/LethalProgression/Skills/BatteryLife.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using HarmonyLib;
+﻿using HarmonyLib;
 
 namespace LethalProgression.Skills
 {

--- a/LethalProgression/Skills/HPRegen.cs
+++ b/LethalProgression/Skills/HPRegen.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using GameNetcodeStuff;
+﻿using GameNetcodeStuff;
 using HarmonyLib;
 using UnityEngine;
 

--- a/LethalProgression/Skills/HandSlots.cs
+++ b/LethalProgression/Skills/HandSlots.cs
@@ -1,10 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 using UnityEngine;
 using Object = UnityEngine.Object;
 using UnityEngine.UI;
-using UnityEngine.InputSystem.Utilities;
 using GameNetcodeStuff;
 
 namespace LethalProgression.Skills

--- a/LethalProgression/Skills/HandSlots.cs
+++ b/LethalProgression/Skills/HandSlots.cs
@@ -28,7 +28,11 @@ namespace LethalProgression.Skills
 
             // Tell the server we've updated our hand slots.
             ulong playerID = GameNetworkManager.Instance.localPlayerController.playerClientId;
-            xpInstance.ServerHandSlots_ServerRpc(playerID, slotsToAdd);
+
+            LethalPlugin.Log.LogInfo($"Updating Player HandSlot {playerID}");
+
+            xpInstance.updateSPHandSlotsClientMessage.SendServer(slotsToAdd);
+
         }
 
         public static void UpdateHudSlots()

--- a/LethalProgression/Skills/JumpHeight.cs
+++ b/LethalProgression/Skills/JumpHeight.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using GameNetcodeStuff;
-using HarmonyLib;
+﻿using GameNetcodeStuff;
 
 namespace LethalProgression.Skills
 {

--- a/LethalProgression/Skills/LootValue.cs
+++ b/LethalProgression/Skills/LootValue.cs
@@ -1,4 +1,4 @@
-using HarmonyLib;
+﻿using HarmonyLib;
 
 namespace LethalProgression.Skills
 {
@@ -15,7 +15,10 @@ namespace LethalProgression.Skills
             if (!LP_NetworkManager.xpInstance.skillList.IsSkillValid(UpgradeType.Value))
                 return;
 
-            float scrapValueAdded = LP_NetworkManager.xpInstance.teamLootValue.Value / 100;
+            float mult = LP_NetworkManager.xpInstance.skillList.skills[UpgradeType.Value].GetMultiplier();
+            float value = LP_NetworkManager.xpInstance.teamLootLevel.Value * mult;
+
+            float scrapValueAdded = value / 100;
 
             try
             {

--- a/LethalProgression/Skills/LootValue.cs
+++ b/LethalProgression/Skills/LootValue.cs
@@ -37,7 +37,7 @@ namespace LethalProgression.Skills
             if (!LP_NetworkManager.xpInstance.skillList.IsSkillValid(UpgradeType.Value))
                 return;
 
-            LP_NetworkManager.xpInstance.TeamLootLevelUpdate(change);
+            LP_NetworkManager.xpInstance.updateTeamLootLevelClientMessage.SendServer(change);
         }
     }
 }

--- a/LethalProgression/Skills/LootValue.cs
+++ b/LethalProgression/Skills/LootValue.cs
@@ -37,7 +37,7 @@ namespace LethalProgression.Skills
             if (!LP_NetworkManager.xpInstance.skillList.IsSkillValid(UpgradeType.Value))
                 return;
 
-            LP_NetworkManager.xpInstance.TeamLootValueUpdate(change);
+            LP_NetworkManager.xpInstance.TeamLootLevelUpdate(change);
         }
     }
 }

--- a/LethalProgression/Skills/LootValue.cs
+++ b/LethalProgression/Skills/LootValue.cs
@@ -1,5 +1,4 @@
 using HarmonyLib;
-using Unity.Netcode;
 
 namespace LethalProgression.Skills
 {

--- a/LethalProgression/Skills/LootValue.cs
+++ b/LethalProgression/Skills/LootValue.cs
@@ -1,6 +1,3 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using HarmonyLib;
 using Unity.Netcode;
 

--- a/LethalProgression/Skills/Oxygen.cs
+++ b/LethalProgression/Skills/Oxygen.cs
@@ -42,6 +42,9 @@ namespace LethalProgression.Skills
         [HarmonyPatch(typeof(PlayerControllerB), "LateUpdate")]
         private static void OxygenUpdate(PlayerControllerB __instance)
         {
+            if (!LP_NetworkManager.xpInstance)
+                return;
+
             if (!LP_NetworkManager.xpInstance.skillList.IsSkillListValid())
                 return;
 

--- a/LethalProgression/Skills/Oxygen.cs
+++ b/LethalProgression/Skills/Oxygen.cs
@@ -13,18 +13,21 @@ namespace LethalProgression.Skills
         private static float oxygenTimer = 0f;
         private static bool inWater = false;
         private static bool canDrown = true;
+
         [HarmonyPostfix]
         [HarmonyPatch(typeof(PlayerControllerB), "SetFaceUnderwaterClientRpc")]
         private static void EnteredWater(PlayerControllerB __instance)
         {
             inWater = true;
         }
+
         [HarmonyPostfix]
         [HarmonyPatch(typeof(PlayerControllerB), "SetFaceOutOfWaterClientRpc")]
         private static void LeftWater(PlayerControllerB __instance)
         {
             inWater = false;
         }
+
         [HarmonyPrefix]
         [HarmonyPatch(typeof(PlayerControllerB), "SetFaceUnderwaterFilters")]
         private static void ShouldDrown(PlayerControllerB __instance)
@@ -34,11 +37,11 @@ namespace LethalProgression.Skills
                 StartOfRound.Instance.drowningTimer = 99f;
             }
         }
+
         [HarmonyPostfix]
         [HarmonyPatch(typeof(PlayerControllerB), "LateUpdate")]
         private static void OxygenUpdate(PlayerControllerB __instance)
         {
-
             if (!LP_NetworkManager.xpInstance.skillList.IsSkillListValid())
                 return;
 
@@ -48,23 +51,22 @@ namespace LethalProgression.Skills
             if (__instance.isPlayerDead)
             {
                 if (oxygenBar)
-                {
                     oxygenBar.SetActive(false);
-                }
+
                 return;
             }
 
             if (LP_NetworkManager.xpInstance.skillList.skills[UpgradeType.Oxygen].GetLevel() == 0)
             {
                 if (oxygenBar)
-                {
                     oxygenBar.SetActive(false);
-                }
+
                 if (!canDrown)
                 {
                     canDrown = true;
                     StartOfRound.Instance.drowningTimer = 1f;
                 }
+                
                 return;
             }
 
@@ -73,6 +75,7 @@ namespace LethalProgression.Skills
 
             Skill skill = LP_NetworkManager.xpInstance.skillList.skills[UpgradeType.Oxygen];
             float maxOxygen = skill.GetTrueValue();
+
             if (inWater)
             {
                 oxygenBar.SetActive(true);
@@ -98,6 +101,7 @@ namespace LethalProgression.Skills
                     oxygenTimer -= Time.deltaTime;
                 }
             }
+
             if (!inWater)
             {
                 if (oxygenTimer <= 0f)
@@ -119,16 +123,19 @@ namespace LethalProgression.Skills
                     oxygenTimer -= Time.deltaTime;
                 }
             }
+
             if (oxygen > maxOxygen)
             {
                 oxygenBar.SetActive(false);
                 oxygen = maxOxygen;
             }
+
             if (oxygenBar.activeSelf)
             {
                 float fill = oxygen / maxOxygen;
                 oxygenBar.transform.GetChild(0).GetChild(0).GetComponent<Image>().fillAmount = fill;
             }
+
             //LethalPlugin.Log.LogInfo($"Underwater: {__instance.isUnderwater} | Oxygen: {oxygen} | Oxygen Timer: {oxygenTimer} | In Water: {inWater}");
         }
         public static void CreateOxygenBar()

--- a/LethalProgression/Skills/Oxygen.cs
+++ b/LethalProgression/Skills/Oxygen.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using HarmonyLib;
+﻿using HarmonyLib;
 using GameNetcodeStuff;
 using UnityEngine;
 using UnityEngine.UI;

--- a/LethalProgression/Skills/SprintSpeed.cs
+++ b/LethalProgression/Skills/SprintSpeed.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection.Emit;
-using System.Text;
-using BepInEx.Bootstrap;
 using GameNetcodeStuff;
 using HarmonyLib;
-using BepInEx.Configuration;
 
 namespace LethalProgression.Skills
 {

--- a/LethalProgression/Skills/Stamina.cs
+++ b/LethalProgression/Skills/Stamina.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using GameNetcodeStuff;
-using HarmonyLib;
+﻿using GameNetcodeStuff;
 
 namespace LethalProgression.Skills
 {

--- a/LethalProgression/Skills/Strength.cs
+++ b/LethalProgression/Skills/Strength.cs
@@ -1,10 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using GameNetcodeStuff;
 using HarmonyLib;
-using Unity.Netcode;
 
 namespace LethalProgression.Skills
 {

--- a/LethalProgression/XP.cs
+++ b/LethalProgression/XP.cs
@@ -1,13 +1,6 @@
-﻿using HarmonyLib;
-using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
-using System.Text;
 using Unity.Netcode;
-using Unity.Networking;
 using UnityEngine;
-using System.IO;
-using UnityEngine.SceneManagement;
 using System.Collections;
 using GameNetcodeStuff;
 using LethalProgression.Config;
@@ -16,7 +9,6 @@ using LethalProgression.GUI;
 using LethalProgression.Patches;
 using LethalProgression.Saving;
 using Newtonsoft.Json;
-using Steamworks;
 using System.Linq;
 
 namespace LethalProgression

--- a/thunderstore.toml
+++ b/thunderstore.toml
@@ -14,6 +14,7 @@ containsNsfwContent = false
 [package.dependencies]
 # https://thunderstore.io/c/lethal-company/p/BepInEx/BepInExPack/
 BepInEx-BepInExPack = "5.4.2100"
+xilophor-LethalNetworkAPI = "2.1.6"
 
 [build]
 icon = "icon.png"


### PR DESCRIPTION
Due to falling into a rabbit hole of trying to fix the Save Profile data syncing issue I took a wrong turn on the cause.

I wrongly believed Netcode Patcher was causing an issue with triggering ServerRPC events from Clients during the Disconnect pre-patch, in an attempt to remedy the situation I used LethalNetworkAPI and rebuilt the entire Network layer of the mod.
_This did not fix the issue_
Turns out it just doesn't fire because on the next-frame the connection would be closed.

In this update:
- Entire network layer is rebuilt with clearer naming conventions on each Event and Message.
- Clients request saving their profile data **PER ACTION**
- Team Loot Value is now synced by combined level rather than by the multiplier. 
    - This allows for an accurate number to reduce by per-client disconnection
- Error in `Oxygen.OxygenUpdate` should no longer occur, handler was called pre-network initialisation
- General refactor of code to tidy it up and make it more readable