### PR TITLE
Bug Fixes

### DIFF
--- a/.github/actions/init/action.yml
+++ b/.github/actions/init/action.yml
@@ -10,7 +10,7 @@ runs:
   using: composite
   steps:
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 7.0.405
 

--- a/LethalProgression/Network/PlayerJumpHeightData.cs
+++ b/LethalProgression/Network/PlayerJumpHeightData.cs
@@ -1,0 +1,8 @@
+namespace LethalProgression.Network;
+
+internal class PlayerJumpHeightData
+{
+    public ulong clientId;
+
+    public int jumpSkillValue;
+}

--- a/LethalProgression/Patches/Config.cs
+++ b/LethalProgression/Patches/Config.cs
@@ -53,21 +53,21 @@ namespace LethalProgression.Config
 
             // Skill Configs
             LethalPlugin.Instance.BindConfig<bool>(
-                "Skills",
+                "Health",
                 "Health Regen Enabled",
                 true,
                 "Enable the Health Regen skill?"
             );
 
             LethalPlugin.Instance.BindConfig<int>(
-                "Skills",
+                "Health",
                 "Health Regen Max Level",
                 20,
                 "Maximum level for the health regen."
             );
 
             LethalPlugin.Instance.BindConfig<float>(
-                "Skills",
+                "Health",
                 "Health Regen Multiplier",
                 0.05f,
                 "How much does the health regen skill increase per level?"
@@ -75,21 +75,21 @@ namespace LethalProgression.Config
 
             //
             LethalPlugin.Instance.BindConfig<bool>(
-                "Skills",
+                "Stamina",
                 "Stamina Enabled",
                 true,
                 "Enable the Stamina skill?"
             );
 
             LethalPlugin.Instance.BindConfig<int>(
-                "Skills",
+                "Stamina",
                 "Stamina Max Level",
                 99999,
                 "Maximum level for the stamina."
             );
 
             LethalPlugin.Instance.BindConfig<float>(
-                "Skills",
+                "Stamina",
                 "Stamina Multiplier",
                 2,
                 "How much does the stamina skill increase per level?"
@@ -97,21 +97,21 @@ namespace LethalProgression.Config
 
             //
             LethalPlugin.Instance.BindConfig<bool>(
-                "Skills",
+                "Battery",
                 "Battery Life Enabled",
                 true,
                 "Enable the Battery Life skill?"
             );
 
             LethalPlugin.Instance.BindConfig<int>(
-                "Skills",
+                "Battery",
                 "Battery Life Max Level",
                 99999,
                 "Maximum level for the battery life."
             );
 
             LethalPlugin.Instance.BindConfig<float>(
-                "Skills",
+                "Battery",
                 "Battery Life Multiplier",
                 5,
                 "How much does the battery life skill increase per level?"
@@ -119,21 +119,21 @@ namespace LethalProgression.Config
 
             //
             LethalPlugin.Instance.BindConfig<bool>(
-                "Skills",
+                "Hand Slots",
                 "Hand Slots Enabled",
                 true,
                 "Enable the Hand Slots skill?"
             );
 
             LethalPlugin.Instance.BindConfig<int>(
-                "Skills",
+                "Hand Slots",
                 "Hand Slots Max Level",
                 30,
                 "Maximum level for the hand slots."
             );
 
             LethalPlugin.Instance.BindConfig<float>(
-                "Skills",
+                "Hand Slots",
                 "Hand Slots Multiplier",
                 10,
                 "How much does the hand slots skill increase per level?"
@@ -141,21 +141,21 @@ namespace LethalProgression.Config
 
             //
             LethalPlugin.Instance.BindConfig<bool>(
-                "Skills",
+                "Loot Value",
                 "Loot Value Enabled",
                 true,
                 "Enable the Loot Value skill?"
             );
 
             LethalPlugin.Instance.BindConfig<int>(
-                "Skills",
+                "Loot Value",
                 "Loot Value Max Level",
                 250,
                 "Maximum level for the loot value."
             );
 
             LethalPlugin.Instance.BindConfig<float>(
-                "Skills",
+                "Loot Value",
                 "Loot Value Multiplier",
                 0.1f,
                 "How much does the loot value skill increase per level?"
@@ -163,84 +163,87 @@ namespace LethalProgression.Config
 
             //
             LethalPlugin.Instance.BindConfig<bool>(
-                "Skills",
+                "Oxygen",
                 "Oxygen Enabled",
                 true,
                 "Enable the Oxygen skill?"
             );
 
             LethalPlugin.Instance.BindConfig<int>(
-                "Skills",
+                "Oxygen",
                 "Oxygen Max Level",
                 99999,
                 "Maximum level for Oxygen."
             );
 
             LethalPlugin.Instance.BindConfig<float>(
-                "Skills",
+                "Oxygen",
                 "Oxygen Multiplier",
                 1f,
                 "How much does the Oxygen skill increase per level?"
             );
+
             //
             LethalPlugin.Instance.BindConfig<bool>(
-                "Skills",
+                "Jump Height",
                 "Jump Height Enabled",
                 true,
                 "Enable the Jump Height skill?"
             );
 
             LethalPlugin.Instance.BindConfig<int>(
-                "Skills",
+                "Jump Height",
                 "Jump Height Max Level",
                 99999,
                 "Maximum level for Jump Height."
             );
 
             LethalPlugin.Instance.BindConfig<float>(
-                "Skills",
+                "Jump Height",
                 "Jump Height Multiplier",
                 3f,
                 "How much does the Jump Height skill increase per level?"
             );
+
             //
             LethalPlugin.Instance.BindConfig<bool>(
-                "Skills",
+                "Sprint Speed",
                 "Sprint Speed Enabled",
                 true,
                 "Enable the Sprint Speed skill?"
             );
 
             LethalPlugin.Instance.BindConfig<int>(
-                "Skills",
+                "Sprint Speed",
                 "Sprint Speed Max Level",
                 99999,
                 "Maximum level for Sprint Speed."
             );
 
             LethalPlugin.Instance.BindConfig<float>(
-                "Skills",
+                "Sprint Speed",
                 "Sprint Speed Multiplier",
-                0.25f,
+                0.75f,
                 "How much does the Sprint Speed skill increase per level?"
             );
+
             //
             LethalPlugin.Instance.BindConfig<bool>(
-                "Skills",
+                "Strength",
                 "Strength Enabled",
                 true,
                 "Enable the strength skill?"
             );
 
             LethalPlugin.Instance.BindConfig<int>(
-                "Skills",
+                "Strength",
                 "Strength Max Level",
                 75,
                 "Maximum level for Strength."
             );
 
             LethalPlugin.Instance.BindConfig<float>(
-                "Skills",
+                "Strength",
                 "Strength Multiplier",
                 1f,
                 "How much does the Strength skill increase per level?"

--- a/LethalProgression/Patches/EnemyAIPatch.cs
+++ b/LethalProgression/Patches/EnemyAIPatch.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using HarmonyLib;
-using LethalProgression.Components;
 
 namespace LethalProgression.Patches
 {

--- a/LethalProgression/Patches/EnemyAIPatch.cs
+++ b/LethalProgression/Patches/EnemyAIPatch.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+using HarmonyLib;
+using LethalProgression.Components;
+
+namespace LethalProgression.Patches
+{
+    [HarmonyPatch]
+    internal class EnemyAIPatch
+    {
+        private static Dictionary<string, int> _enemyReward = new Dictionary<string, int>()
+        {
+            { "HoarderBug (EnemyType)" , 30 },
+            { "BaboonBird (EnemyType)", 15},
+            { "MouthDog (EnemyType)", 200},
+            { "Centipede (EnemyType)", 30 },
+            { "Flowerman (EnemyType)", 200 },
+            { "SandSpider (EnemyType)", 50 },
+            { "Crawler (EnemyType)", 50 },
+            { "Puffer (EnemyType)", 15 },
+        };
+
+        [HarmonyPostfix]
+        [HarmonyPatch(typeof(EnemyAI), "KillEnemy")]
+        private static void CalculateXPForEnemyDeath(EnemyAI __instance)
+        {
+            // Only trigger on host
+            if (!GameNetworkManager.Instance.isHostingGame)
+                return;
+
+            string enemyType = __instance.enemyType.ToString();
+            LethalPlugin.Log.LogInfo("Enemy type: " + enemyType);
+            
+            // Give XP for the amount of money this scrap costs.
+            int enemyReward = 30;
+            if (_enemyReward.ContainsKey(enemyType))
+            {
+                enemyReward = _enemyReward[enemyType];
+            }
+
+            LP_NetworkManager.xpInstance.updateTeamXPClientMessage.SendServer(enemyReward);
+        }
+
+        [HarmonyPostfix]
+        [HarmonyPatch(typeof(EnemyAI), "HitEnemyServerRpc")]
+        private static void HitEnemyTrigger(EnemyAI __instance, int force, int playerWhoHit)
+        {
+            LethalPlugin.Log.LogInfo($"Player {playerWhoHit} hit enemy {__instance.GetType()} with force {force}");
+            // __instance.GetInstanceID();
+
+            // rpc the instance id + player id
+
+            // on server add or get the tracker
+            // foreach (EnemyAI enemy in RoundManager.Instance.SpawnedEnemies)
+            // {
+            //     if (enemy.GetInstanceID() == __instance.GetInstanceID()) {
+            //         enemy.gameObject.AddComponent(typeof(EnemyDamageTrackerComponent));
+            //     }
+            // }
+
+            // todo: Set a component on the Server instance of Enemy which informs us of
+            /////////
+            /// TODO
+            /// - Send Server RPC with enemy identifier and player identifier
+            /// - Set a component on the EnemyAI that says who hit the enemy
+            /// - On Death check for component on the Server
+        }
+    }
+}

--- a/LethalProgression/Patches/HudManagerPatch.cs
+++ b/LethalProgression/Patches/HudManagerPatch.cs
@@ -17,18 +17,6 @@ namespace LethalProgression.Patches
         private static GameObject levelText;
         private static float levelTextTime;
 
-        private static Dictionary<string, int> _enemyReward = new Dictionary<string, int>()
-        {
-            { "HoarderBug (EnemyType)" , 30 },
-            { "BaboonBird (EnemyType)", 15},
-            { "MouthDog (EnemyType)", 200},
-            { "Centipede (EnemyType)", 30 },
-            { "Flowerman (EnemyType)", 200 },
-            { "SandSpider (EnemyType)", 50 },
-            { "Crawler (EnemyType)", 50 },
-            { "Puffer (EnemyType)", 15 },
-        };
-
         // [HarmonyPostfix]
         // [HarmonyPatch(typeof(HUDManager), "PingScan_performed")]
         // private static void DebugScan()
@@ -48,23 +36,6 @@ namespace LethalProgression.Patches
 
             // Give XP for the amount of money this scrap costs.
             LP_NetworkManager.xpInstance.updateTeamXPClientMessage.SendServer(scrapCost);
-        }
-        
-        [HarmonyPostfix]
-        [HarmonyPatch(typeof(EnemyAI), "KillEnemy")]
-        private static void GiveXPForKill(EnemyAI __instance)
-        {
-            string enemyType = __instance.enemyType.ToString();
-            LethalPlugin.Log.LogInfo("Enemy type: " + enemyType);
-            
-            // Give XP for the amount of money this scrap costs.
-            int enemyReward = 30;
-            if (_enemyReward.ContainsKey(enemyType))
-            {
-                enemyReward = _enemyReward[enemyType];
-            }
-
-            LP_NetworkManager.xpInstance.updateTeamXPClientMessage.SendServer(enemyReward);
         }
 
         public static void ShowXPUpdate()

--- a/LethalProgression/Skills/HPRegen.cs
+++ b/LethalProgression/Skills/HPRegen.cs
@@ -11,7 +11,10 @@ namespace LethalProgression.Skills
         [HarmonyPatch(typeof(PlayerControllerB), "LateUpdate")]
         private static void HPRegenUpdate(PlayerControllerB __instance)
         {
-            if (__instance.health >= 100)
+            if (!__instance.IsOwner || (__instance.IsServer && !__instance.isHostPlayerObject))
+                return;
+
+            if (!__instance.isPlayerControlled || __instance.health >= 100 || __instance.isPlayerDead)
                 return;
 
             if (!LP_NetworkManager.xpInstance.skillList.IsSkillListValid())
@@ -35,12 +38,13 @@ namespace LethalProgression.Skills
                 {
                     __instance.MakeCriticallyInjured(false);
                 }
+
                 HUDManager.Instance.UpdateHealthUI(__instance.health, false);
+
+                return;
             }
-            else
-            {
-                __instance.healthRegenerateTimer -= Time.deltaTime;
-            }
+            
+            __instance.healthRegenerateTimer -= Time.deltaTime;
         }
     }
 }

--- a/LethalProgression/Skills/JumpHeight.cs
+++ b/LethalProgression/Skills/JumpHeight.cs
@@ -1,4 +1,6 @@
 ﻿using GameNetcodeStuff;
+using LethalProgression.Network;
+using Newtonsoft.Json;
 
 namespace LethalProgression.Skills
 {
@@ -12,12 +14,18 @@ namespace LethalProgression.Skills
             if (!LP_NetworkManager.xpInstance.skillList.IsSkillValid(UpgradeType.JumpHeight))
                 return;
 
-            Skill skill = LP_NetworkManager.xpInstance.skillList.skills[UpgradeType.JumpHeight];
             PlayerControllerB localPlayer = GameNetworkManager.Instance.localPlayerController;
-            // 5 is 100%. So if 1 level adds 1% more, then it is 5 * 1.01.
-            float addedJump = (updatedValue * skill.GetMultiplier() / 100f) * 5f;
-            localPlayer.jumpForce += addedJump;
-            LethalPlugin.Log.LogInfo($"{updatedValue} change, Adding {addedJump} resulting in {localPlayer.jumpForce} jump force");
+            Skill skill = LP_NetworkManager.xpInstance.skillList.skills[UpgradeType.JumpHeight];
+
+            PlayerJumpHeightData networkData = new PlayerJumpHeightData()
+            {
+                clientId = localPlayer.playerClientId,
+                jumpSkillValue = skill.GetLevel()
+            };
+
+            LethalPlugin.Log.LogInfo($"Jump skill now {updatedValue}, sending to Server");
+            
+            LP_NetworkManager.xpInstance.updatePlayerJumpForceClientMessage.SendServer(networkData);
         }
     }
 }


### PR DESCRIPTION
- [x] Fix HP Regen updating the HUD for all players when 1 player took damage
- [x] Refactor the EnemyAI Patch ready for better checks
- [x] Fix Enemy Kill XP being applied by all clients instead of just Host
- [x] Fix Jump height not being synced to all players (tested to +5000 jump increase)
- [x] Re-categorised the config to make it more readable and bumped the default Speed multiplied from 0.25 to 0.75,
    - `50 levels x 0.25 = 12.5% increase`
    - `50 levels x 0.75 = 37.5% increase`
    - 0.25 was not showing a useful enough increase even when putting all levels into it.
    - This option is still configurable