### PR TITLE
fixes for jump height

### DIFF
--- a/LethalProgression/Patches/StartOfRoundPatch.cs
+++ b/LethalProgression/Patches/StartOfRoundPatch.cs
@@ -1,0 +1,24 @@
+using HarmonyLib;
+using LethalProgression.Skills;
+
+namespace LethalProgression.Patches
+{
+    
+    [HarmonyPatch]
+    internal class StartOfRoundPatch
+    {
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(StartOfRound), "ResetMiscValues")]
+        private static void ResetMiscValues_PrePatch()
+        {
+            JumpHeight.JumpHeightUpdate(0);
+        }
+        
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(StartOfRound), "OnShipLandedMiscEvents")]
+        private static void OnShipLandedMiscEvents_PrePatch()
+        {
+            JumpHeight.JumpHeightUpdate(0);
+        }
+    }
+}

--- a/LethalProgression/Skills/JumpHeight.cs
+++ b/LethalProgression/Skills/JumpHeight.cs
@@ -23,7 +23,7 @@ namespace LethalProgression.Skills
                 jumpSkillValue = skill.GetLevel()
             };
 
-            LethalPlugin.Log.LogInfo($"Jump skill now {updatedValue}, sending to Server");
+            LethalPlugin.Log.LogInfo($"Jump skill now {skill.GetLevel()}, sending to Server");
             
             LP_NetworkManager.xpInstance.updatePlayerJumpForceClientMessage.SendServer(networkData);
         }

--- a/LethalProgression/XP.cs
+++ b/LethalProgression/XP.cs
@@ -542,9 +542,9 @@ namespace LethalProgression
             Skill skill = LP_NetworkManager.xpInstance.skillList.skills[UpgradeType.JumpHeight];
 
             // 10 is 100%. So if 1 level adds 1% more, then it is 10 * 1.01.
-            float addedJump = playerData.jumpSkillValue * skill.GetMultiplier() / 100f * 10f;
+            float addedJump = playerData.jumpSkillValue * skill.GetMultiplier() / 100f * 13f;
 
-            playerController.jumpForce = 10f + addedJump;
+            playerController.jumpForce = 13f + addedJump;
 
             LethalPlugin.Log.LogInfo($"Updating client {playerData.clientId} jump height. Adding {addedJump} resulting in {playerController.jumpForce} jump force");
         }


### PR DESCRIPTION
After testing some bugs were found with jump height resetting on lobby load and revival.

Also the base jump height was incorrectly set to 10 instead of 13.