### PR TITLE
v2.3.2

### DIFF
--- a/LethalProgression/Config/HealthRegenConfig.cs
+++ b/LethalProgression/Config/HealthRegenConfig.cs
@@ -16,7 +16,7 @@ interface IHealthRegenConfig
     int maxLevel { get; }
 
     [ConfigName("Health Regen Multiplier")]
-    [ConfigDescription("How much does the health regen skill increase per level?")]
-    [ConfigDefault(0.5f)]
+    [ConfigDescription("**Warning** - Making this multiplier too high will make you almost never lose HP. Multiplier x Max Level should equal 1 at most. (1hp every 1 second)")]
+    [ConfigDefault(0.05f)]
     float multiplier { get; }
 }

--- a/LethalProgression/Patches/PlayerControllerB/PlayerControllerBPatch.cs
+++ b/LethalProgression/Patches/PlayerControllerB/PlayerControllerBPatch.cs
@@ -125,20 +125,24 @@ internal class PlayerControllerBPatch
         if (!LP_NetworkManager.xpInstance.skillList.IsSkillValid(UpgradeType.HPRegen))
             return;
 
+
+        if (__instance.health < 20 && __instance.healthRegenerateTimer > 1f)
+            __instance.healthRegenerateTimer = 1f;
+
         if (__instance.healthRegenerateTimer > 0f)
-        {
-            __instance.healthRegenerateTimer -= Time.deltaTime;
-            return;
-        }
+            {
+                __instance.healthRegenerateTimer -= Time.deltaTime;
+                return;
+            }
 
         if (__instance.health >= 20)
             __instance.MakeCriticallyInjured(false);
 
         if (__instance.health >= maxHealth)
             return;
-        
-        Skill skill = LP_NetworkManager.xpInstance.skillList.skills[UpgradeType.HPRegen];
 
+
+        Skill skill = LP_NetworkManager.xpInstance.skillList.skills[UpgradeType.HPRegen];
         // Then turn that into seconds. So, if hps is 0.5, then it will take 2 seconds to regen 1 health.
         float newRegenerateTimer = 1f / skill.GetTrueValue(); // 1 / (0.05 * 5 = 0.25) = 4
 

--- a/LethalProgression/Patches/PlayerControllerB/PlayerControllerBPatch.cs
+++ b/LethalProgression/Patches/PlayerControllerB/PlayerControllerBPatch.cs
@@ -138,8 +138,14 @@ internal class PlayerControllerBPatch
             return;
         
         Skill skill = LP_NetworkManager.xpInstance.skillList.skills[UpgradeType.HPRegen];
+
         // Then turn that into seconds. So, if hps is 0.5, then it will take 2 seconds to regen 1 health.
-        __instance.healthRegenerateTimer = 1f / skill.GetTrueValue(); // 0.05 * 5 = 0.25
+        float newRegenerateTimer = 1f / skill.GetTrueValue(); // 1 / (0.05 * 5 = 0.25) = 4
+
+        if (__instance.health < 20 && newRegenerateTimer > 1f)
+            newRegenerateTimer = 1f;
+
+        __instance.healthRegenerateTimer = newRegenerateTimer;
         __instance.health++;
 
         HUDManager.Instance.UpdateHealthUI(__instance.health, false);


### PR DESCRIPTION
- fix: re-enable the vanilla style critical regen
- fix: ensure when critically injured the timer is reset to 1s